### PR TITLE
Refactor uninstall logic for previous XCP-ng Center versions

### DIFF
--- a/xcp-ng-center/tools/chocolateyinstall.ps1
+++ b/xcp-ng-center/tools/chocolateyinstall.ps1
@@ -1,26 +1,45 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$xcpng_old64 = Test-Path -Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{45CFD130-100D-4868-BE0C-EA772261E950}"
-$xcpng_old32 = Test-Path -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{45CFD130-100D-4868-BE0C-EA772261E950}"
+# Previous XCP-ng Center versions used a different MSI GUID. Uninstall if found.
+$oldGuid = '{45CFD130-100D-4868-BE0C-EA772261E950}'
+$oldUninstallPaths = @(
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$oldGuid",
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$oldGuid"
+)
 
-if ($xcpng_old64 -or $xcpng_old32) {
-  Invoke-Expression -Command (Join-Path -Path $toolsDir -ChildPath "chocolateyuninstall.ps1")
+foreach ($path in $oldUninstallPaths) {
+    if (Test-Path -Path $path) {
+        Write-Host "Uninstalling previous XCP-ng Center version with GUID $oldGuid from $path"
+        $uninstallString = (Get-ItemProperty -Path $path).UninstallString
+        if ($uninstallString) {
+            $uninstallArgs = @{
+                packageName   = "XCP-ng Center (old GUID)"
+                fileType      = 'MSI'
+                silentArgs    = "/qn /norestart"
+                validExitCodes= @(0, 3010, 1605, 1614, 1641)
+                file          = ''
+            }
+            # For MSI, pass the product code as silentArgs
+            $uninstallArgs['silentArgs'] = "$oldGuid $($uninstallArgs['silentArgs'])"
+            Uninstall-ChocolateyPackage @uninstallArgs
+        }
+    }
 }
 
-$url        = 'https://github.com/xcp-ng/xenadmin/releases/download/v25.04/XCP-ng.Center.msi'
+$url = 'https://github.com/xcp-ng/xenadmin/releases/download/v25.04/XCP-ng.Center.msi'
 
 $packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  unzipLocation = $toolsDir
-  fileType      = 'MSI'
-  url           = $url
-  softwareName  = 'XCP-ng Center*'
-  checksum      = '58B7FF485C821C13FF3EA0D3C75F207680B1DCE51DE00C08AFE805D3E421325D'
-  checksumType  = 'sha256'
-  silentArgs    = "/qn"
-  validExitCodes= @(0, 3010, 1641)
+    packageName   = $env:ChocolateyPackageName
+    unzipLocation = $toolsDir
+    fileType      = 'MSI'
+    url           = $url
+    softwareName  = 'XCP-ng Center*'
+    checksum      = '58B7FF485C821C13FF3EA0D3C75F207680B1DCE51DE00C08AFE805D3E421325D'
+    checksumType  = 'sha256'
+    silentArgs    = "/qn"
+    validExitCodes= @(0, 3010, 1641)
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Improve the uninstall process for older XCP-ng Center versions by checking for the previous MSI GUID and executing the uninstall command if found.