### PR TITLE
Update Citrix Enterprise Browser version and checksum

### DIFF
--- a/Citrix-Enterprise-Browser/Citrix-Enterprise-Browser.nuspec
+++ b/Citrix-Enterprise-Browser/Citrix-Enterprise-Browser.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>citrix-enterprise-browser</id>
     <title>Citrix Enterprise Browser</title>
-    <version>131.1.1.37</version>
+    <version>137.1.1.25</version>
     <authors>Citrix Systems Inc.</authors>
     <owners>Martin Nygaard Jensen</owners>
     <summary>Citrix Enterprise Browser</summary>
@@ -42,9 +42,9 @@ Cisco Webex
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>Citrix CEB EnterpriseBrowser Browser</tags>
     <docsUrl>https://docs.citrix.com/en-us/citrix-enterprise-browser</docsUrl>
-    <releaseNotes>https://docs.citrix.com/en-us/citrix-enterprise-browser/whats-new#whats-new-in-1311132</releaseNotes>
+    <releaseNotes>https://docs.citrix.com/en-us/citrix-enterprise-browser/whats-new#whats-new-in-1371125</releaseNotes>
     <dependencies>
-      <dependency id="citrix-workspace" version="24.5.11" />
+      <dependency id="citrix-workspace" version="25.3" />
     </dependencies>
     <packageSourceUrl>https://github.com/ravager-dk/Chocolatey-Packages/tree/master/Citrix-Enterprise-Browser</packageSourceUrl>
   </metadata>

--- a/Citrix-Enterprise-Browser/tools/ChocolateyInstall.ps1
+++ b/Citrix-Enterprise-Browser/tools/ChocolateyInstall.ps1
@@ -3,8 +3,8 @@
 #Citrix uses dynamic download links that expire, likely for telemetry reasons. in some cases they provide direct download links, but not in this case. As a result the script needs to parse the download page to get the current dynamic link.
 
 #region version variables
-$version = "131"
-$Checksum = "FD2BC9B71F6F989EC4C7B11D333A9BBA2415C66660A396A4E4FA76F4F2DB792F";
+$version = "137"
+$Checksum = "FB9A4A06444167215033AE049A779BC48D5B0F3F64D2E08AB342E39166556CFE";
 $ChecksumType = "sha256";
 #endregion version variables
 


### PR DESCRIPTION
Upgrade the Citrix Enterprise Browser to version 137.1.1.25 and update the corresponding checksum in the installation script.