### PR TITLE
Update Zoom VDI Client and Universal Plugin to version 6.4.12.26620

### DIFF
--- a/Zoom-VDI-Client/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Client/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url      = "https://zoom.us/download/vdi/6.4.11.26350/ZoomInstallerVDI.msi?archType=x64"
+$url      = "https://zoom.us/download/vdi/6.4.12.26620/ZoomInstallerVDI.msi?archType=x64"
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64          = $url
   softwareName   = 'Zoom Client for VDI*'
 
-  checksum64     = 'B2747D20A56EDCEE70F62EAE470C01775EB6080E2F6C088787DFDD827A7A5D2D'
+  checksum64     = 'DFB2D13C9DB375D8629ABD6C2C1EC5DC39E94ED0F29C4D8266A0B6EF7FA25890'
   checksumType64 = 'sha256'
 
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Client/zoom-vdi-client.nuspec
+++ b/Zoom-VDI-Client/zoom-vdi-client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-client</id>
-    <version>6.4.11.26350</version>
+    <version>6.4.12.26620</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Client</title>
     <authors>Zoom Video Communications, Inc</authors>

--- a/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64      = "https://zoom.us/download/vdi/6.4.11.26350/ZoomVDIUniversalPluginx64.msi?archType=x64"
+$url64      = "https://zoom.us/download/vdi/6.4.12.26620/ZoomVDIUniversalPluginx64.msi?archType=x64"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64         = $url64
   softwareName  = 'Zoom VDI Universal Plugin*'
 
-  checksum64      = '402001DF2B44E457C31EC80140C3FAFE4763DF30A32805C3FE78F40DA5C25515'
+  checksum64      = '9CE8DBD7986E1B4372272A1A97B5CC06895AEB8BD799DD1026D55868E2A77B0C'
   checksumType64  = 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
+++ b/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-universal-plugin</id>
-    <version>6.4.11.26350</version>
+    <version>6.4.12.26620</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Universal Plugin</title>
     <authors>Zoom Video Communications, Inc</authors>


### PR DESCRIPTION
Upgrade the Zoom VDI Client and Universal Plugin to the latest version, ensuring the download URLs and checksums are updated accordingly.