### PR TITLE
Bump Zoom VDI Client and Universal Plugin to 6.5.10.26710

### DIFF
--- a/Zoom-VDI-Client/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Client/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url      = "https://zoom.us/download/vdi/6.4.12.26620/ZoomInstallerVDI.msi?archType=x64"
+$url      = "https://zoom.us/download/vdi/6.5.10.26710/ZoomInstallerVDI.msi?archType=x64"
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64          = $url
   softwareName   = 'Zoom Client for VDI*'
 
-  checksum64     = 'DFB2D13C9DB375D8629ABD6C2C1EC5DC39E94ED0F29C4D8266A0B6EF7FA25890'
+  checksum64     = '2591524E20C45E373A44728D3C21D7E13D3F84BC611926826D981CD955B401F2'
   checksumType64 = 'sha256'
 
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Client/zoom-vdi-client.nuspec
+++ b/Zoom-VDI-Client/zoom-vdi-client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-client</id>
-    <version>6.4.12.26620</version>
+    <version>6.5.10.26710</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Client</title>
     <authors>Zoom Video Communications, Inc</authors>

--- a/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64      = "https://zoom.us/download/vdi/6.4.12.26620/ZoomVDIUniversalPluginx64.msi?archType=x64"
+$url64      = "https://zoom.us/download/vdi/6.5.10.26710/ZoomVDIUniversalPluginx64.msi?archType=x64"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64         = $url64
   softwareName  = 'Zoom VDI Universal Plugin*'
 
-  checksum64      = '9CE8DBD7986E1B4372272A1A97B5CC06895AEB8BD799DD1026D55868E2A77B0C'
+  checksum64      = 'A0D96F82922F99E5A877BA204346FFACC3D331721C0BFEDB01E20ACBF10DB677'
   checksumType64  = 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
+++ b/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-universal-plugin</id>
-    <version>6.4.12.26620</version>
+    <version>6.5.10.26710</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Universal Plugin</title>
     <authors>Zoom Video Communications, Inc</authors>


### PR DESCRIPTION
Update versions, download URLs, and checksums for the Zoom VDI Client and Universal Plugin.