### PR TITLE
Bump Zoom to version 6.5.11.26770

### DIFF
--- a/Zoom-VDI-Client/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Client/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url      = "https://zoom.us/download/vdi/6.5.10.26710/ZoomInstallerVDI.msi?archType=x64"
+$url      = "https://zoom.us/download/vdi/6.5.11.26770/ZoomInstallerVDI.msi?archType=x64"
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64          = $url
   softwareName   = 'Zoom Client for VDI*'
 
-  checksum64     = '2591524E20C45E373A44728D3C21D7E13D3F84BC611926826D981CD955B401F2'
+  checksum64     = '8AE43A05DF3183896AC76F03B29E70B6CE019AD6D3636EB5B72559D62F39F3F0'
   checksumType64 = 'sha256'
 
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Client/zoom-vdi-client.nuspec
+++ b/Zoom-VDI-Client/zoom-vdi-client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-client</id>
-    <version>6.5.10.26710</version>
+    <version>6.5.11.26770</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Client</title>
     <authors>Zoom Video Communications, Inc</authors>

--- a/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
+++ b/Zoom-VDI-Universal-Plugin/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64      = "https://zoom.us/download/vdi/6.5.10.26710/ZoomVDIUniversalPluginx64.msi?archType=x64"
+$url64      = "https://zoom.us/download/vdi/6.5.11.26770/ZoomVDIUniversalPluginx64.msi?archType=x64"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
   url64         = $url64
   softwareName  = 'Zoom VDI Universal Plugin*'
 
-  checksum64      = 'A0D96F82922F99E5A877BA204346FFACC3D331721C0BFEDB01E20ACBF10DB677'
+  checksum64      = '8237311C800792A01A78103571ADA52B2B472BAEFF6BE52FAB4FA29EC5C8ED47'
   checksumType64  = 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" DISABLEAUS=TRUE"

--- a/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
+++ b/Zoom-VDI-Universal-Plugin/zoom-vdi-universal-plugin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>zoom-vdi-universal-plugin</id>
-    <version>6.5.10.26710</version>
+    <version>6.5.11.26770</version>
     <owners>Martin Nygaard Jensen</owners>
     <title>Zoom VDI Universal Plugin</title>
     <authors>Zoom Video Communications, Inc</authors>


### PR DESCRIPTION
Update Zoom and Zoom VDI Universal Plugin to version 6.5.11.26770, including corresponding URLs and checksums.